### PR TITLE
Allow Vue 3 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "vue": "^2.6.10"
+    "vue": "^2.6.10 || ^3.0.0"
   },
   "bugs": {
     "url": "https://github.com/palerdot/vue-speedometer/issues"


### PR DESCRIPTION
I have no problem using this component in Vue3. However, `npm` version 8 started complaining about the peer dependency.