### PR TITLE
Updated d3 version from 5.9.2 to 7.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "d3": "^5.9.2",
+    "d3": "^7.8.5",
     "lodash-es": "^4.17.15",
     "memoize-one": "^5.0.5"
   },


### PR DESCRIPTION
Support for [Vulnerability in D3 library #59]

There were no problems with local testing.（Probably no problem）